### PR TITLE
docs: add GitHub Pull Request template

### DIFF
--- a/terraform/.github/pull_request_template.md
+++ b/terraform/.github/pull_request_template.md
@@ -1,0 +1,42 @@
+# 📋 Pull Request
+
+## 📄 Description
+
+> Please include a summary of the changes and the related issue if applicable.
+
+---
+
+## 🛠 Type of Change
+
+- [ ] ✨ New feature
+- [ ] 🐛 Bug fix
+- [ ] ♻️ Refactor (no functional change)
+- [ ] 🧹 Code quality improvement (linting, format, CI)
+- [ ] 📝 Documentation update
+- [ ] 🚀 Performance improvement
+- [ ] 🛡️ Test coverage improvement
+- [ ] ⚙️ Build/deployment changes
+
+---
+
+## ✅ Checklist
+
+- [ ] My code follows the existing code style.
+- [ ] I have added or updated tests where necessary.
+- [ ] I have updated the README if needed.
+- [ ] I have tested the application locally.
+- [ ] The build and tests are passing (`make up`, `make test`, `make lint`).
+
+---
+
+## 🧠 Additional Notes
+
+> Deployment risks? Rollback considerations? Known limitations?
+> Anything else for reviewers or devops to know.
+
+---
+
+# 🚀 Related Issues (if any)
+
+> Closes #ISSUE_ID
+> Related to #ISSUE_ID


### PR DESCRIPTION
## 📄 Description

This PR introduces a standard GitHub Pull Request template under `.github/pull_request_template.md`.  
It ensures all PRs are consistently documented with descriptions, checklists, and type labels.

---

## 🛠 Type of Change

- [x] 📝 Documentation update (PR templates)

---

## ✅ Checklist

- [x] Created `.github/pull_request_template.md`
- [x] Validated template renders correctly on PR creation
- [x] No application code was changed