### PR TITLE
feat(ci): upload Terraform plan to S3 and download for apply

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -38,11 +38,9 @@ jobs:
           fi
         working-directory: terraform
 
-      - name: Download Plan Artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: tfplan-${{ github.sha }}
-          path: .
+      - name: Download tfplan from S3
+        run: |
+          aws s3 cp s3://hello-birthday-api-tfstate/tfplans/${{ github.sha }}.tfplan tfplan
 
       - name: Verify tfplan exists
         run: |

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -102,6 +102,10 @@ jobs:
           path: terraform/plan.txt
           retention-days: 7
 
+      - name: Upload tfplan to S3
+        run: |
+          aws s3 cp terraform/tfplan s3://hello-birthday-api-tfstate/tfplans/${{ github.sha }}.tfplan
+
       - name: Comment Terraform Plan on PR
         uses: marocchino/sticky-pull-request-comment@v2
         with:


### PR DESCRIPTION
# 📋 Pull Request

## 📄 Description

This PR introduces changes to improve how Terraform plans are handled in our CI/CD pipeline:
After generating a tfplan, the binary plan file is uploaded securely to an S3 bucket (hello-birthday-api-tfplans).
During the apply workflow, the saved tfplan is downloaded from S3 before applying.
This ensures reproducibility, traceability, and separation of plan/apply stages across workflows.

---

## 🛠 Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor (no functional change)
- [x] 🧹 Code quality improvement (linting, format, CI)
- [ ] 📝 Documentation update
- [ ] 🚀 Performance improvement
- [ ] 🛡️ Test coverage improvement
- [x] ⚙️ Build/deployment changes

