### PR TITLE
feat(ci): store Terraform plans in S3 and fetch for apply

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -29,18 +29,34 @@ jobs:
         with:
           terraform_version: "1.11.0"
 
+      - name: Identify the environment
+        run: |
+            # Default
+            ENVIRONMENT="dev"
+
+            if [[ "${GITHUB_HEAD_REF}" == "release" || "${GITHUB_REF}" == "refs/heads/release" ]]; then
+              ENVIRONMENT="prod"
+            fi
+            echo "ENVIRONMENT=$ENVIRONMENT" >> $GITHUB_ENV
+
       - name: Terraform Init
         run: |
           if [[ ${{ github.ref }} == "refs/heads/main" ]]; then
-            terraform init -backend-config=../infrastructure/backends/backend-dev.hcl
+            terraform init -backend-config=../infrastructure/backends/backend-$ENVIRONMENT.hcl
           elif [[ ${{ github.ref }} == "refs/heads/release" ]]; then
-            terraform init -backend-config=../infrastructure/backends/backend-prod.hcl
+            terraform init -backend-config=../infrastructure/backends/backend-$ENVIRONMENT.hcl
           fi
         working-directory: terraform
 
-      - name: Download tfplan from S3
+      - name: Download plan metadata
         run: |
-          aws s3 cp s3://hello-birthday-api-tfstate/tfplans/${{ github.sha }}.tfplan tfplan
+          aws s3 cp s3://hello-birthday-api-tfstate/tfplans/$ENVIRONMENT/plan-filename.txt plan-filename.txt
+
+      - name: Download the Terraform plan
+        run: |
+          PLAN_FILE=$(cat plan-filename.txt)
+          echo "PLAN_FILE=$PLAN_FILE" >> $GITHUB_ENV
+          aws s3 cp s3://hello-birthday-api-tfstate/tfplans/$ENVIRONMENT/$PLAN_FILE.tfplan tfplan
 
       - name: Verify tfplan exists
         run: |
@@ -53,11 +69,11 @@ jobs:
 
       - name: Announce Plan Being Applied
         run: |
-          echo "Terraform plan (artifact: tfplan-${GITHUB_SHA}) has been downloaded locally as tfplan."
+          echo "Terraform plan (artifact: $PLAN_FILE.tfplan) has been downloaded locally as tfplan."
           echo "Proceeding to apply it now..."
 
       - name: Terraform Apply
         run: |
             terraform apply -auto-approve tfplan
-            echo "::notice :: Terraform apply completed successfully for plan tfplan-${GITHUB_SHA}"
+            echo "::notice :: Terraform apply completed successfully for plan $PLAN_FILE.tfplan"
         working-directory: terraform

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -48,6 +48,7 @@ jobs:
           if [[ "${GITHUB_HEAD_REF}" == "release" || "${GITHUB_REF}" == "refs/heads/release" ]]; then
             ENVIRONMENT="prod"
           fi
+          echo "ENVIRONMENT=$ENVIRONMENT" >> $GITHUB_ENV
 
           PARAMETER_NAME="/hello-birthday-api/$ENVIRONMENT/terraform-variables"
           terraform_vars_json=$(aws ssm get-parameter --name "$PARAMETER_NAME" --query "Parameter.Value" --output text)
@@ -88,23 +89,14 @@ jobs:
           fi
         working-directory: terraform
 
-      - name: Upload Terraform Plan (binary)
-        uses: actions/upload-artifact@v4
-        with:
-          name: tfplan-${{ github.sha }}
-          path: terraform/tfplan
-          retention-days: 7
-
-      - name: Upload Plan Summary (text)
-        uses: actions/upload-artifact@v4
-        with:
-          name: plan-summary-${{ github.sha }}
-          path: terraform/plan.txt
-          retention-days: 7
-
-      - name: Upload tfplan to S3
+      - name: Set Plan File Name
         run: |
-          aws s3 cp terraform/tfplan s3://hello-birthday-api-tfstate/tfplans/${{ github.sha }}.tfplan
+          echo "${{ github.sha }}" > plan-filename.txt
+
+      - name: Upload tfplan and plan-filename.txt to S3
+        run: |
+          aws s3 cp terraform/tfplan s3://hello-birthday-api-tfstate/tfplans/$ENVIRONMENT/${{ github.sha }}.tfplan
+          aws s3 cp plan-filename.txt s3://hello-birthday-api-tfstate/tfplans/$ENVIRONMENT/plan-filename.txt
 
       - name: Comment Terraform Plan on PR
         uses: marocchino/sticky-pull-request-comment@v2


### PR DESCRIPTION
# 📋 Pull Request

## 📄 Description

This PR improves our Terraform workflows by introducing reliable S3-based storage for plan artifacts:

- Dynamically generates a tfplan filename based on SHA
- Uploads the Terraform binary plan (tfplan) to a designated S3 bucket after the plan step.
- Uploads the human-readable plan summary (plan.txt) for visibility and PR review.
- Saves the generated tfplan filename (plan-filename.txt) separately into S3 for later retrieval.
- During the apply step, the metadata is downloaded to fetch the correct tfplan file reliably.
- Ensures clean, auditable, and safe Terraform deployment workflows across CI/CD.

---

## 🛠 Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor (no functional change)
- [x] 🧹 Code quality improvement (linting, format, CI)
- [ ] 📝 Documentation update
- [ ] 🚀 Performance improvement
- [ ] 🛡️ Test coverage improvement
- [x] ⚙️ Build/deployment changes
