### PR TITLE
feat(terraform): add RDS module with secure VPC integration

### DIFF
--- a/terraform/envs/dev.tfvars.example
+++ b/terraform/envs/dev.tfvars.example
@@ -19,3 +19,10 @@ availability_zones = [
 ]
 
 flow_logs_retention_days = 30
+
+name_prefix             = "hello-birthday-dev"
+engine                 = "mysql"
+instance_class         = "db.t3.micro"
+allocated_storage      = 20
+username               = "username"
+password               = "password"

--- a/terraform/envs/dev.tfvars.example
+++ b/terraform/envs/dev.tfvars.example
@@ -18,8 +18,6 @@ availability_zones = [
   "us-east-1b"
 ]
 
-flow_logs_retention_days = 30
-
 name_prefix             = "hello-birthday-dev"
 engine                 = "mysql"
 instance_class         = "db.t3.micro"

--- a/terraform/envs/prod.tfvars.example
+++ b/terraform/envs/prod.tfvars.example
@@ -22,3 +22,11 @@ availability_zones = [
 ]
 
 flow_logs_retention_days = 365
+
+name_prefix             = "hello-birthday-prd"
+env                    = "prod"
+engine                 = "mysql"
+instance_class         = "db.m6g.large""
+allocated_storage      = 100
+username               = "username"
+password               = "password"

--- a/terraform/envs/prod.tfvars.example
+++ b/terraform/envs/prod.tfvars.example
@@ -21,8 +21,6 @@ availability_zones = [
   "us-east-1c"
 ]
 
-flow_logs_retention_days = 365
-
 name_prefix             = "hello-birthday-prd"
 env                    = "prod"
 engine                 = "mysql"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -9,3 +9,16 @@ module "vpc" {
   private_subnet_cidrs = var.private_subnet_cidrs
   availability_zones   = var.availability_zones
 }
+
+module "rds" {
+  source              = "./modules/rds"
+  name_prefix          = var.name_prefix
+  env                 = var.env
+  engine              = var.engine
+  instance_class      = var.instance_class
+  allocated_storage   = var.allocated_storage
+  username            = var.username
+  password            = var.password
+  subnet_ids          = module.vpc.private_subnet_ids
+  security_group_ids  = [module.vpc.rds_security_group_id]
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -11,14 +11,14 @@ module "vpc" {
 }
 
 module "rds" {
-  source              = "./modules/rds"
-  name_prefix          = var.name_prefix
-  env                 = var.env
-  engine              = var.engine
-  instance_class      = var.instance_class
-  allocated_storage   = var.allocated_storage
-  username            = var.username
-  password            = var.password
-  subnet_ids          = module.vpc.private_subnet_ids
-  security_group_ids  = [module.vpc.rds_security_group_id]
+  source             = "./modules/rds"
+  name_prefix        = var.name_prefix
+  env                = var.env
+  engine             = var.engine
+  instance_class     = var.instance_class
+  allocated_storage  = var.allocated_storage
+  username           = var.username
+  password           = var.password
+  subnet_ids         = module.vpc.private_subnet_ids
+  security_group_ids = [module.vpc.rds_security_group_id]
 }

--- a/terraform/modules/rds/main.tf
+++ b/terraform/modules/rds/main.tf
@@ -1,0 +1,26 @@
+resource "aws_db_subnet_group" "this" {
+  name       = "${var.name_prefix}-subnet-group"
+  subnet_ids = var.subnet_ids
+
+  tags = {
+    Name = "${var.name_prefix}-subnet-group"
+    Environment = var.env
+  }
+}
+
+resource "aws_db_instance" "this" {
+  identifier        = "${var.name_prefix}-db"
+  engine            = var.engine
+  instance_class    = var.instance_class
+  allocated_storage = var.allocated_storage
+  username          = var.username
+  password          = var.password
+  db_subnet_group_name = aws_db_subnet_group.this.name
+  vpc_security_group_ids = var.security_group_ids
+  skip_final_snapshot = true
+
+  tags = {
+    Name = "${var.name_prefix}-db"
+    Environment = var.env
+  }
+}

--- a/terraform/modules/rds/main.tf
+++ b/terraform/modules/rds/main.tf
@@ -3,24 +3,42 @@ resource "aws_db_subnet_group" "this" {
   subnet_ids = var.subnet_ids
 
   tags = {
-    Name = "${var.name_prefix}-subnet-group"
+    Name        = "${var.name_prefix}-subnet-group"
+    Environment = var.env
+  }
+}
+
+resource "aws_kms_key" "performance_insights" {
+  description             = "KMS key for encrypting RDS Performance Insights"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+
+  tags = {
+    Name        = "${var.name_prefix}-rds-pi-key"
     Environment = var.env
   }
 }
 
 resource "aws_db_instance" "this" {
-  identifier        = "${var.name_prefix}-db"
-  engine            = var.engine
-  instance_class    = var.instance_class
-  allocated_storage = var.allocated_storage
-  username          = var.username
-  password          = var.password
-  db_subnet_group_name = aws_db_subnet_group.this.name
-  vpc_security_group_ids = var.security_group_ids
-  skip_final_snapshot = true
+  identifier                          = "${var.name_prefix}-db"
+  engine                              = var.engine
+  instance_class                      = var.instance_class
+  allocated_storage                   = var.allocated_storage
+  username                            = var.username
+  password                            = var.password
+  db_subnet_group_name                = aws_db_subnet_group.this.name
+  vpc_security_group_ids              = var.security_group_ids
+  storage_encrypted                   = true
+  skip_final_snapshot                 = true
+  deletion_protection                 = true
+  iam_database_authentication_enabled = true
+  performance_insights_enabled        = true
+  performance_insights_kms_key_id     = aws_kms_key.performance_insights.arn
+
+  backup_retention_period = 7
 
   tags = {
-    Name = "${var.name_prefix}-db"
+    Name        = "${var.name_prefix}-db"
     Environment = var.env
   }
 }

--- a/terraform/modules/rds/outputs.tf
+++ b/terraform/modules/rds/outputs.tf
@@ -1,0 +1,7 @@
+output "rds_endpoint" {
+  value = aws_db_instance.this.endpoint
+}
+
+output "rds_instance_id" {
+  value = aws_db_instance.this.id
+}

--- a/terraform/modules/rds/variables.tf
+++ b/terraform/modules/rds/variables.tf
@@ -1,0 +1,47 @@
+variable "name_prefix" {
+  description = "Prefix for naming resources"
+  type        = string
+}
+
+variable "env" {
+  description = "Environment name (dev/prod)"
+  type        = string
+}
+
+variable "engine" {
+  description = "Database engine (e.g., mysql)"
+  type        = string
+  default     = "mysql"
+}
+
+variable "instance_class" {
+  description = "Instance type for RDS"
+  type        = string
+  default     = "db.t3.micro"
+}
+
+variable "allocated_storage" {
+  description = "Storage size in GB"
+  type        = number
+  default     = 20
+}
+
+variable "username" {
+  description = "Master username for RDS"
+  type        = string
+}
+
+variable "password" {
+  description = "Master password for RDS"
+  type        = string
+}
+
+variable "subnet_ids" {
+  description = "List of private subnet IDs for RDS"
+  type        = list(string)
+}
+
+variable "security_group_ids" {
+  description = "List of security group IDs"
+  type        = list(string)
+}

--- a/terraform/modules/vpc/main.tf
+++ b/terraform/modules/vpc/main.tf
@@ -113,14 +113,15 @@ resource "aws_security_group" "rds" {
   }
 
   egress {
+    description = "Allow all outbound traffic within VPC"
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = [var.vpc_cidr]
   }
 
   tags = {
-    Name = "${var.name}-rds-sg"
+    Name        = "${var.name}-rds-sg"
     Environment = var.env
   }
 }

--- a/terraform/modules/vpc/main.tf
+++ b/terraform/modules/vpc/main.tf
@@ -98,3 +98,29 @@ resource "aws_flow_log" "vpc_flow_logs" {
   log_destination_type = "cloud-watch-logs"
   traffic_type         = "ALL"
 }
+
+resource "aws_security_group" "rds" {
+  name        = "${var.name}-rds-sg"
+  description = "Allow MySQL access from VPC private subnets only"
+  vpc_id      = aws_vpc.this.id
+
+  ingress {
+    description = "MySQL from private subnets"
+    from_port   = 3306
+    to_port     = 3306
+    protocol    = "tcp"
+    cidr_blocks = var.private_subnet_cidrs
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${var.name}-rds-sg"
+    Environment = var.env
+  }
+}

--- a/terraform/modules/vpc/outputs.tf
+++ b/terraform/modules/vpc/outputs.tf
@@ -12,3 +12,8 @@ output "private_subnet_ids" {
   description = "IDs of private subnets"
   value       = aws_subnet.private[*].id
 }
+
+output "rds_security_group_id" {
+  description = "Security Group ID for RDS"
+  value       = aws_security_group.rds.id
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -35,11 +35,6 @@ variable "availability_zones" {
   type        = list(string)
 }
 
-variable "flow_logs_retention_days" {
-  description = "Retention period for VPC Flow Logs in CloudWatch Logs (in days)"
-  type        = number
-}
-
 variable "name_prefix" {
   description = "Prefix for resource names"
   type        = string

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -34,3 +34,40 @@ variable "availability_zones" {
   description = "List of availability zones to use"
   type        = list(string)
 }
+
+variable "flow_logs_retention_days" {
+  description = "Retention period for VPC Flow Logs in CloudWatch Logs (in days)"
+  type        = number
+}
+
+variable "name_prefix" {
+  description = "Prefix for resource names"
+  type        = string
+}
+
+
+variable "engine" {
+  description = "Database engine type"
+  type        = string
+  default     = "mysql"
+}
+
+variable "instance_class" {
+  description = "RDS instance type"
+  type        = string
+}
+
+variable "allocated_storage" {
+  description = "RDS allocated storage size"
+  type        = number
+}
+
+variable "username" {
+  description = "Master username for RDS"
+  type        = string
+}
+
+variable "password" {
+  description = "Master password for RDS"
+  type        = string
+}


### PR DESCRIPTION
# 📋 Pull Request

## 📄 Description

This PR introduces a new Terraform module for managing RDS instances in AWS.  
It ensures production-readiness by integrating securely with the VPC module:

- RDS instances are deployed in private subnets.
- Access is restricted to MySQL port (3306) via a security group.
- Dynamic subnet IDs and security group IDs are passed from the VPC module.
- Different configurations for `dev` and `prod` environments are supported.

---

## 🛠 Type of Change

- [x] ✨ New feature

---

## ✅ Checklist

- [x] I added a new RDS Terraform module.
- [x] I updated the VPC module outputs to export private subnets and RDS security group ID.
- [x] I tested Terraform plan locally (`terraform init -reconfigure && terraform plan`).
- [x] I updated variables and outputs accordingly.
- [x] No breaking changes introduced.
