### PR TITLE
fix(vpc): add IAM role and CloudWatch log group for flow logs

### DIFF
--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -80,7 +80,7 @@ jobs:
           tflint --init
           tflint --call-module-type=all
 
-      - name: Run tfsec (Security Checks) #disabled some tfsec tests for DEV
+      - name: Run tfsec for DEV (Security Checks) #disabled some tfsec tests for DEV
         run: tfsec --config-file terraform/envs/dev/.tfsec.yaml terraform/envs/dev/
 
       - name: Run tfsec for Prod

--- a/terraform/modules/vpc/main.tf
+++ b/terraform/modules/vpc/main.tf
@@ -147,7 +147,7 @@ resource "aws_flow_log" "vpc_flow_logs" {
   vpc_id               = aws_vpc.this.id
   log_destination      = aws_cloudwatch_log_group.vpc_flow_logs.arn
   log_destination_type = "cloud-watch-logs"
-  iam_role_arn              = aws_iam_role.flow_logs_role.arn
+  iam_role_arn         = aws_iam_role.flow_logs_role.arn
   traffic_type         = "ALL"
 }
 


### PR DESCRIPTION
# 📋 Pull Request

## 📄 Description

Updates the aws_flow_log resource to use iam_role_arn.
Fixes the error:
InvalidParameter: DeliverLogsPermissionArn can't be empty if LogDestinationType is cloud-watch-logs

---

## 🛠 Type of Change

- [ ] ✨ New feature
- [x] 🐛 Bug fix
- [x] ♻️ Refactor (no functional change)
- [ ] 🧹 Code quality improvement (linting, format, CI)
- [ ] 📝 Documentation update
- [ ] 🚀 Performance improvement
- [ ] 🛡️ Test coverage improvement
- [ ] ⚙️ Build/deployment changes
