### PR TITLE
Update hello-birthday-api image to 1.0.33

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -1,2 +1,2 @@
 hello-birthday-api:
-  image: ghcr.io/cerepx/hello-birthday-api:1.0.30
+  image: ghcr.io/cerepx/hello-birthday-api:1.0.33


### PR DESCRIPTION
This PR updates the hello-birthday-api Docker image version to `1.0.33`.