### PR TITLE
fix(terraform): update ECS container port from 5050 to 5000

### DIFF
--- a/terraform/modules/alb/main.tf
+++ b/terraform/modules/alb/main.tf
@@ -8,7 +8,7 @@ resource "aws_lb" "this" {
 
 resource "aws_lb_target_group" "this" {
   name     = "hello-birthday-api-tg"
-  port     = 5050
+  port     = 5000
   protocol = "HTTP"
   vpc_id   = var.vpc_id
 

--- a/terraform/modules/ecs_service/main.tf
+++ b/terraform/modules/ecs_service/main.tf
@@ -13,8 +13,8 @@ resource "aws_ecs_task_definition" "this" {
       image = var.container_image
       portMappings = [
         {
-          containerPort = 5050
-          hostPort      = 5050
+          containerPort = 5000
+          hostPort      = 5000
           protocol      = "tcp"
         }
       ]
@@ -67,7 +67,7 @@ resource "aws_ecs_service" "this" {
   load_balancer {
     target_group_arn = var.target_group_arn
     container_name   = var.container_name
-    container_port   = 5050
+    container_port   = 5000
   }
 
   task_definition = aws_ecs_task_definition.this.arn

--- a/terraform/modules/vpc/main.tf
+++ b/terraform/modules/vpc/main.tf
@@ -185,8 +185,8 @@ resource "aws_security_group" "ecs" {
 
   ingress {
     description = "HTTP from ALB"
-    from_port   = 5050
-    to_port     = 5050
+    from_port   = 5000
+    to_port     = 5000
     protocol    = "tcp"
     cidr_blocks = [var.vpc_cidr]
   }


### PR DESCRIPTION
# 📋 Pull Request

## 📄 Description

This PR updates the ECS service Terraform configuration to use port 5000 instead of 5050 for container traffic.
The application inside the container now listens on port 5000, requiring the update to match the ALB target configuration.

### Notes about Fargate
- In Fargate, each task has its **own Elastic Network Interface (ENI)** and its own networking stack.
- **There is no concept of a shared host port**.
- The Application Load Balancer (ALB) targets the **private IP** and **container port** directly.

Therefore, only `container_port` needs to be updated — no host port mapping is necessary.

---

## 🛠 Type of Change

- [ ] ✨ New feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor (no functional change)
- [ ] 🧹 Code quality improvement (linting, format, CI)
- [ ] 📝 Documentation update
- [ ] 🚀 Performance improvement
- [ ] 🛡️ Test coverage improvement
- [ ] ⚙️ Build/deployment changes

