### PR TITLE
chore(ci): add labeler config for automated PR labeling

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,21 @@
+# Labeler rules for auto-tagging PRs
+
+feat:
+  - '.github/workflows/**'
+  - 'terraform/modules/**'
+
+infra:
+  - 'terraform/**'
+
+ci:
+  - '.github/workflows/**'
+
+rds:
+  - 'terraform/modules/rds/**'
+
+alb:
+  - 'terraform/modules/alb/**'
+
+ecs:
+  - 'terraform/modules/ecs_cluster/**'
+  - 'terraform/modules/ecs_service/**'

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -29,11 +29,6 @@ jobs:
         with:
           terraform_version: "1.11.0"
 
-      - name: Install MySQL client
-        run: |
-            sudo apt-get update
-            sudo apt-get install -y mysql-client
-
       - name: Identify the environment
         run: |
             # Default

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -144,8 +144,9 @@ jobs:
           aws s3 cp terraform/tfplan s3://hello-birthday-api-tfstate/tfplans/$ENVIRONMENT/${{ github.sha }}.tfplan
           aws s3 cp plan-filename.txt s3://hello-birthday-api-tfstate/tfplans/$ENVIRONMENT/plan-filename.txt
 
-      - name: Comment Terraform Plan on PR
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          header: terraform-plan
-          path: terraform/plan.txt
+      # This is disabled because the repo is public and we don't want to expose the plan that contains ARNs and other sensitive data
+      # - name: Comment Terraform Plan on PR
+      #   uses: marocchino/sticky-pull-request-comment@v2
+      #   with:
+      #     header: terraform-plan
+      #     path: terraform/plan.txt


### PR DESCRIPTION
# 📋 Pull Request

## 📄 Description

This PR adds a `.github/labeler.yml` configuration file to enable automatic labeling of pull requests based on the files they modify.

### Added Labels and Match Rules
- **feat**: Changes in `.github/workflows/**` or `terraform/modules/**`
- **infra**: Changes in any `terraform/**`
- **ci**: Changes in `.github/workflows/**`
- **rds**: Changes in `terraform/modules/rds/**`
- **alb**: Changes in `terraform/modules/alb/**`
- **ecs**: Changes in `terraform/modules/ecs_cluster/**` and `terraform/modules/ecs_service/**`

### Why
Automating PR labeling helps categorize and triage changes faster, improves review workflow, and supports better changelog generation if needed.
